### PR TITLE
Add unit tests for PlayerProfile color validation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,4 +32,7 @@ dependencies {
   implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'com.google.android.material:material:1.12.0'
 
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+
 }

--- a/app/src/test/java/com/spiritwisestudios/inkrollers/model/PlayerProfileTest.kt
+++ b/app/src/test/java/com/spiritwisestudios/inkrollers/model/PlayerProfileTest.kt
@@ -1,0 +1,30 @@
+import com.spiritwisestudios.inkrollers.model.PlayerColorPalette
+import com.spiritwisestudios.inkrollers.model.PlayerProfile
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlayerProfileTest {
+    @Test
+    fun `isValidColorSelection returns true with three distinct valid colors`() {
+        val colors = PlayerColorPalette.COLORS.take(3)
+        val profile = PlayerProfile(favoriteColors = colors)
+        assertTrue(profile.isValidColorSelection())
+    }
+
+    @Test
+    fun `isValidColorSelection returns false with duplicate colors`() {
+        val color = PlayerColorPalette.COLORS.first()
+        val colors = listOf(color, color, PlayerColorPalette.COLORS[1])
+        val profile = PlayerProfile(favoriteColors = colors)
+        assertFalse(profile.isValidColorSelection())
+    }
+
+    @Test
+    fun `isValidColorSelection returns false with an invalid color`() {
+        val invalidColor = 0x000000
+        val colors = listOf(PlayerColorPalette.COLORS[0], PlayerColorPalette.COLORS[1], invalidColor)
+        val profile = PlayerProfile(favoriteColors = colors)
+        assertFalse(profile.isValidColorSelection())
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerProfileTest covering valid and invalid color selections
- enable JUnit dependencies for local unit tests

## Testing
- `./gradlew test` *(fails: No route to host)*