### PR TITLE
Update coverage HUD display

### DIFF
--- a/app/src/main/java/com/spiritwisestudios/inkrollers/CoverageHudView.kt
+++ b/app/src/main/java/com/spiritwisestudios/inkrollers/CoverageHudView.kt
@@ -3,6 +3,7 @@ package com.spiritwisestudios.inkrollers
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.graphics.Color
 import android.util.AttributeSet
 import android.view.View
 
@@ -16,19 +17,32 @@ class CoverageHudView @JvmOverloads constructor(
 ) : View(context, attrs, defStyleAttr) {
 
     private var coverageData: Map<Int, Float> = emptyMap()
+    private var leftPlayerColor: Int? = null
+    private var rightPlayerColor: Int? = null
+
     private val paint = Paint().apply { style = Paint.Style.FILL }
+    private val backgroundPaint = Paint().apply { color = Color.DKGRAY }
     private val textPaint = Paint().apply {
-        color = 0xFF000000.toInt()
+        color = Color.WHITE
         textSize = 36f
         isAntiAlias = true
+        textAlign = Paint.Align.CENTER
     }
 
     /**
      * Update coverage percentages and redraw.
      * @param data Map of color (Int) to fraction (0-1)
+     * @param leftColor Color value for the player on the left side of the bar
+     * @param rightColor Color value for the player on the right side of the bar
      */
-    fun updateCoverage(data: Map<Int, Float>) {
+    fun updateCoverage(
+        data: Map<Int, Float>,
+        leftColor: Int? = this.leftPlayerColor,
+        rightColor: Int? = this.rightPlayerColor
+    ) {
         coverageData = data
+        this.leftPlayerColor = leftColor
+        this.rightPlayerColor = rightColor
         postInvalidate()
     }
 
@@ -36,45 +50,36 @@ class CoverageHudView @JvmOverloads constructor(
         super.onDraw(canvas)
         val data = coverageData
         if (data.isEmpty()) return
-        
-        // Configuration: gutter and min bar width in pixels
-        val density = resources.displayMetrics.density
-        val baseGutter = 8f * density
-        val minBarWidth = 16f * density
-        val textMargin = 4f * density
-        
-        // Text metrics to reserve bottom space
-        val fm = textPaint.fontMetrics
-        val textHeight = fm.descent - fm.ascent
-        // Baseline for drawing text: above bottom by descent and margin
-        val baselineY = height.toFloat() - fm.descent - textMargin
-        // Bottom of bars should be above the text by margin
-        val barBottom = baselineY - textMargin
-        
-        // Compute maximum text width for gutter
-        val pctStrings = data.values.map { "${(it * 100).toInt()}%" }
-        val maxTextWidth = pctStrings.map { textPaint.measureText(it) }.maxOrNull() ?: 0f
-        val gutter = maxOf(baseGutter, maxTextWidth / 2f + textMargin)
-        
-        val n = data.size
-        val totalGutter = (n + 1) * gutter
-        val availableWidth = width - totalGutter
-        val barWidth = (availableWidth / n).coerceAtLeast(minBarWidth)
-        
-        data.entries.forEachIndexed { index, (color, fraction) ->
-            paint.color = color
-            // Compute left edge for this bar
-            val left = gutter + index * (barWidth + gutter)
-            // Compute bar top based on fraction and reserved barBottom
-            val top = barBottom - (barBottom * fraction)
-            val right = left + barWidth
-            // Draw bar within reserved area
-            canvas.drawRect(left, top, right, barBottom, paint)
-            
-            // Draw text at baseline
-            val pctText = "${(fraction * 100).toInt()}%"
-            val textX = left + barWidth / 2f
-            canvas.drawText(pctText, textX, baselineY, textPaint)
+
+        val halfWidth = width / 2f
+        val barHeight = height.toFloat()
+        val centerY = (barHeight - (textPaint.ascent() + textPaint.descent())) / 2f
+
+        // Draw background bar
+        canvas.drawRect(0f, 0f, width.toFloat(), barHeight, backgroundPaint)
+
+        val leftColor = leftPlayerColor
+        val rightColor = rightPlayerColor
+
+        val leftFraction = if (leftColor != null) data[leftColor] ?: 0f else 0f
+        val rightFraction = if (rightColor != null) data[rightColor] ?: 0f else 0f
+
+        // Left bar grows from the left edge toward the center
+        if (leftColor != null) {
+            paint.color = leftColor
+            val right = (halfWidth * leftFraction).coerceAtMost(halfWidth)
+            canvas.drawRect(0f, 0f, right, barHeight, paint)
+            val pctText = "${(leftFraction * 100).toInt()}%"
+            canvas.drawText(pctText, right / 2f, centerY, textPaint)
+        }
+
+        // Right bar grows from the right edge toward the center
+        if (rightColor != null) {
+            paint.color = rightColor
+            val left = width - (halfWidth * rightFraction).coerceAtMost(halfWidth)
+            canvas.drawRect(left, 0f, width.toFloat(), barHeight, paint)
+            val pctText = "${(rightFraction * 100).toInt()}%"
+            canvas.drawText(pctText, left + (width - left) / 2f, centerY, textPaint)
         }
     }
-} 
+}

--- a/app/src/main/java/com/spiritwisestudios/inkrollers/GameView.kt
+++ b/app/src/main/java/com/spiritwisestudios/inkrollers/GameView.kt
@@ -213,7 +213,11 @@ class GameView @JvmOverloads constructor(ctx:Context,attrs:AttributeSet?=null):
                     val allStats = (currentLevel as MazeLevel).calculateCoverage(surface)
                     val activeColors = players.values.map { it.getColor() }.toSet()
                     val activeStats = allStats.filterKeys { it in activeColors }
-                    coverageHudView?.updateCoverage(activeStats)
+
+                    val leftColor = players["player0"]?.getColor()
+                    val rightColor = players["player1"]?.getColor()
+
+                    coverageHudView?.updateCoverage(activeStats, leftColor, rightColor)
                 } catch (e: Exception) {
                     Log.e(TAG, "Error updating coverage HUD", e)
                 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -27,18 +27,17 @@
       android:id="@+id/ink_hud_view"
       android:layout_width="80dp"
       android:layout_height="150dp"
-      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/coverage_hud_view"
       app:layout_constraintStart_toStartOf="parent"
       android:layout_margin="16dp" />
 
   <com.spiritwisestudios.inkrollers.CoverageHudView
       android:id="@+id/coverage_hud_view"
-      android:layout_width="120dp"
-      android:layout_height="120dp"
-      app:layout_constraintTop_toBottomOf="@id/ink_hud_view"
+      android:layout_width="0dp"
+      android:layout_height="32dp"
+      app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      android:layout_marginStart="16dp"
-      android:layout_marginTop="16dp" />
+      app:layout_constraintEnd_toEndOf="parent" />
 
   <Button
       android:id="@+id/btn_toggle_p2"


### PR DESCRIPTION
## Summary
- redesign `CoverageHudView` to show two coverage bars growing from edges toward the center
- expose orientation info via optional left/right colors
- update `GameView` to provide player colors to the HUD
- reposition HUD elements and resize `CoverageHudView` to span the screen top

## Testing
- `./gradlew test` *(fails: No route to host)*