### PR TITLE
Display corner player names

### DIFF
--- a/app/src/main/java/com/spiritwisestudios/inkrollers/GameView.kt
+++ b/app/src/main/java/com/spiritwisestudios/inkrollers/GameView.kt
@@ -2,6 +2,8 @@ package com.spiritwisestudios.inkrollers
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.SurfaceHolder
@@ -261,11 +263,32 @@ class GameView @JvmOverloads constructor(ctx:Context,attrs:AttributeSet?=null):
         // Log.d(TAG, "GameView.draw() - Drawing player $id")
         player.draw(c)
     }
-    
+
     // Draw local joystick only
     // Log.d(TAG, "GameView.draw() - Before localPlayerId?.let for joystick. localPlayerId: $localPlayerId")
     localPlayerId?.let { joysticks[it]?.draw(c) }
     // Log.d(TAG, "GameView.draw() - After joystick draw.")
+
+    drawCornerNames(c)
+  }
+
+  /** Draw the names of the players in the screen corners. */
+  private fun drawCornerNames(canvas: Canvas) {
+      val textPaint = Paint().apply {
+          color = Color.BLACK
+          textSize = 40f
+          isAntiAlias = true
+          typeface = Typeface.DEFAULT_BOLD
+      }
+      val margin = 16f
+      players["player0"]?.playerName?.takeIf { it.isNotEmpty() }?.let { name ->
+          textPaint.textAlign = Paint.Align.LEFT
+          canvas.drawText(name, margin, margin + textPaint.textSize, textPaint)
+      }
+      players["player1"]?.playerName?.takeIf { it.isNotEmpty() }?.let { name ->
+          textPaint.textAlign = Paint.Align.RIGHT
+          canvas.drawText(name, width - margin, height - margin, textPaint)
+      }
   }
   
   override fun onTouchEvent(e:MotionEvent):Boolean{

--- a/app/src/main/java/com/spiritwisestudios/inkrollers/Player.kt
+++ b/app/src/main/java/com/spiritwisestudios/inkrollers/Player.kt
@@ -137,17 +137,5 @@ class Player(
     val shadowRadius = radius * 0.9f
     c.drawCircle(x + radius * 0.2f, y + radius * 0.2f, shadowRadius, shadowPaint)
 
-    // Draw player name
-    if (playerName.isNotEmpty()) {
-        val textPaint = Paint().apply {
-            color = Color.BLACK // Or a contrasting color
-            textSize = PLAYER_RADIUS * 0.7f // Adjust text size based on player radius
-            textAlign = Paint.Align.CENTER
-            isAntiAlias = true
-            typeface = Typeface.DEFAULT_BOLD // Make name bold
-        }
-        // Draw name centered above the player circle
-        c.drawText(playerName, x, y - PLAYER_RADIUS - 10f, textPaint)
-    }
   }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,7 +29,8 @@
       android:layout_height="150dp"
       app:layout_constraintTop_toTopOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      android:layout_margin="16dp" />
+      android:layout_marginStart="16dp"
+      android:layout_marginTop="64dp" />
 
   <com.spiritwisestudios.inkrollers.CoverageHudView
       android:id="@+id/coverage_hud_view"


### PR DESCRIPTION
## Summary
- move the ink HUD down a bit to make room for player names
- stop drawing player names over each character
- show the names of player0 and player1 in the top‑left and bottom‑right corners

## Testing
- `./gradlew test` *(fails: No route to host)*
- `./gradlew assembleDebug` *(fails: No route to host)*