### PR TITLE
Add Codex setup script for Android build

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install JDK
+sudo apt-get update
+sudo apt-get install -y openjdk-17-jdk unzip curl
+
+# Android SDK installation directory
+ANDROID_SDK_ROOT="$HOME/android-sdk"
+mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+
+# Download and extract Android command line tools
+cd /tmp
+curl -L -o commandlinetools.zip "https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
+unzip -q commandlinetools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
+# Move into expected location
+mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+
+# Install required SDK packages
+yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" --licenses
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" \
+    "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+
+# Create local.properties pointing to the SDK
+cat > local.properties <<EOL
+sdk.dir=$ANDROID_SDK_ROOT
+EOL
+
+# Pre-download Gradle dependencies
+./gradlew --no-daemon assembleDebug

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/local.properties
+/.gradle
+/android-sdk/

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Wed Apr 30 03:09:16 MDT 2025
-sdk.dir=/Users/cthul/Library/Android/sdk


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install the Android SDK and JDK
- ignore `local.properties` and other build artifacts
- remove the repo's stale `local.properties`

## Testing
- `./gradlew test` *(fails: No route to host while trying to download Gradle wrapper)*