### PR TITLE
Adjust maze offset for coverage HUD

### DIFF
--- a/app/src/main/java/com/spiritwisestudios/inkrollers/GameView.kt
+++ b/app/src/main/java/com/spiritwisestudios/inkrollers/GameView.kt
@@ -612,7 +612,8 @@ class GameView @JvmOverloads constructor(ctx:Context,attrs:AttributeSet?=null):
     val seed = multiplayerManager?.mazeSeed?.takeIf { it != 0L } ?: System.currentTimeMillis()
     Log.d(TAG, "Initializing maze with seed: $seed, complexity: $mazeComplexity")
     // Create the level with the synchronized seed and complexity
-    currentLevel = MazeLevel(width, height, 12, 20, 12f, seed, mazeComplexity) // Pass complexity
+    val hudHeight = coverageHudView?.height ?: 0
+    currentLevel = MazeLevel(width, height, 12, 20, 12f, seed, mazeComplexity, hudHeight)
     Log.d(TAG, "Created maze with viewport offset: ${(currentLevel as MazeLevel).getViewportOffset()}")
     
     // Clear previous game objects for a fresh start (especially for rematches)

--- a/app/src/main/java/com/spiritwisestudios/inkrollers/MazeLevel.kt
+++ b/app/src/main/java/com/spiritwisestudios/inkrollers/MazeLevel.kt
@@ -22,7 +22,8 @@ class MazeLevel(
     private val _fixedCellsY_default: Int = 20, // Renamed to avoid confusion
     private val wallThickness: Float = 12f,
     private val seed: Long = System.currentTimeMillis(), // Use provided seed or current time as fallback
-    private val complexity: String = HomeActivity.COMPLEXITY_HIGH // Added complexity parameter
+    private val complexity: String = HomeActivity.COMPLEXITY_HIGH, // Added complexity parameter
+    private val topMargin: Int = 0 // Pixels to offset the maze from the top (e.g. HUD height)
 ) : Level {
 
     private val calculatedCellDimensions: Pair<Int, Int> = run {
@@ -81,8 +82,9 @@ class MazeLevel(
         // Calculate cell size based on screen dimensions and desired cell count
         // Apply a safety margin (0.9) to ensure the maze doesn't touch screen edges
         val safetyMargin = 0.9f
+        val availableHeight = (screenH - topMargin).toFloat()
         val cellW = (screenW.toFloat() * safetyMargin) / cellsX
-        val cellH = (screenH.toFloat() * safetyMargin) / cellsY
+        val cellH = (availableHeight * safetyMargin) / cellsY
         
         // Use the smaller dimension to ensure square cells and full visibility
         cellSize = minOf(cellW, cellH)
@@ -93,7 +95,7 @@ class MazeLevel(
         
         // Center the maze on screen
         viewportOffsetX = (screenW - mazeWidth) / 2
-        viewportOffsetY = (screenH - mazeHeight) / 2
+        viewportOffsetY = topMargin + (availableHeight - mazeHeight) / 2
         
         // Scale walls thickness proportionally but with a min/max bound
         scale = minOf(maxOf(cellSize / 64f, 0.5f), 2.0f) // Keep scale between 0.5 and 2.0


### PR DESCRIPTION
## Summary
- allow specifying a top margin for `MazeLevel`
- offset maze generation so it fits below CoverageHudView

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found or network issues)*